### PR TITLE
Add Hello World menu tool for Renoise

### DIFF
--- a/HelloWorldTool.xrnx/main.lua
+++ b/HelloWorldTool.xrnx/main.lua
@@ -1,0 +1,12 @@
+-- Hello World Tool
+-- Adds a menu entry that shows 'Hello, world!' in the status bar.
+-- See the Renoise API documentation: https://renoise.github.io/xrnx/API/index.htm
+
+local function show_hello()
+  renoise.app():show_status("Hello, world!")
+end
+
+renoise.tool():add_menu_entry{
+  name = "Main Menu:Tools:Hello World Tool:Show Hello",
+  invoke = show_hello
+}

--- a/HelloWorldTool.xrnx/manifest.xml
+++ b/HelloWorldTool.xrnx/manifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tool>
+  <id>com.example.HelloWorld</id>
+  <name>Hello World Tool</name>
+  <version>1.0</version>
+  <author>HexToolsRenoise</author>
+  <description>Displays a Hello World message via a menu item.</description>
+  <autostart>main.lua</autostart>
+</tool>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# HexToolsRenoise
+
+This repository contains example tools for the Renoise digital audio workstation.
+
+## Hello World Tool
+
+`HelloWorldTool.xrnx` is a minimal Renoise tool that adds a menu entry under
+**Tools** called **Hello World Tool**. Selecting **Show Hello** displays
+"Hello, world!" in Renoise's status bar.
+
+### Installation
+
+1. Copy the `HelloWorldTool.xrnx` directory into your Renoise `Tools`
+   folder. Renoise will detect the tool automatically.
+2. In Renoise, open the `Tools` menu and choose `Hello World Tool > Show Hello`.
+
+For more details about developing Renoise tools, see the [official API
+documentation](https://renoise.github.io/xrnx/API/index.htm).


### PR DESCRIPTION
## Summary
- add `HelloWorldTool.xrnx` directory with manifest and menu script
- document the tool in README

## Testing
- `apt-get update` *(fails: domain blocked)*
- `apt-get install -y lua` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c0225b6c832986be055681665b7a