### PR TITLE
Bump version to 0.5.0 in manifest.xml and update GitHub Actions workflow to use git archive for packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       # 5. Zip the package using the version-based filename
       - name: Zip XRNX Package
         run: |
-          zip -x '*.git*' -r "${{ env.FILENAME }}" .
+          git archive -o "${{ env.FILENAME }}" HEAD
 
       # 6. Create and Push Git Tag
       - name: Create and Push Tag

--- a/manifest.xml
+++ b/manifest.xml
@@ -4,7 +4,7 @@
   <Author>Hex</Author>
   <Id>com.hex.HexTools</Id>
   <Name>HeTools</Name>
-  <Version>0.4.0</Version>
+  <Version>0.5.0</Version>
   <Description>Collection of useful tools for Renoise.</Description>
   <KeyBindings>
     <Bindings>


### PR DESCRIPTION
This commit updates the version number in manifest.xml to 0.5.0 and modifies the GitHub Actions workflow to utilize git archive for creating the package. This change enhances the packaging process by ensuring a cleaner archive without including unnecessary files, streamlining the release preparation.